### PR TITLE
Fixes: #7 -add performance comparison to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,9 @@ Installation
 
 Performance
 -----------
+Using Pydantic's benchmarking code, `drf-turbo` serialization performance is 86% faster than DRF's standard serializer.
 
-https://drf-turbo.readthedocs.io/en/latest/performance.html
-
+For more details, visit the [benchmarks section](https://drf-turbo.readthedocs.io/en/latest/performance.html?fbclid=IwAR2kUbUUUWir8vMYPXhFIG7ggsydLlVmtqHlH2yRKm6k1SuvUhm82AyJGnY) of the docs.
 
 Examples
 ========
@@ -180,7 +180,7 @@ Nested Serializers
         email = dt.EmailField()
         created = dt.DateTimeField()
 
-    class Profile : 
+    class Profile :
         def __init__(self, age=25):
             self.age = age
             self.user = user
@@ -192,13 +192,13 @@ Nested Serializers
         age = dt.IntField()
         user = UserSerializer()
 
-    
+
     serializer = ProfileSerializer(profile)
     serializer.data
 
     # {'age' : 25 , 'user' : {'username': 'test', 'email': 'test@example.com', 'created': '2021-11-04T22:49:01.981127Z'}}
 
-    
+
 Filtering Output
 ----------------
 
@@ -208,15 +208,15 @@ drf-turbo provides option to enclude or exclude fields from serializer using ``o
 
     serializer = UserSerializer(user,only=('id','username'))
 
-    or 
+    or
 
     serializer = ProfileSerializer(profile,exclude=('id','user__email'))
 
-    or 
+    or
 
     http://127.0.0.1:8000/user/?only=id,username
 
-    
+
 Required Fields
 ---------------
 
@@ -256,7 +256,7 @@ ModelSerializer
 
 Mapping serializer to Django model definitions.
 
-Features : 
+Features :
 
     * It will automatically generate a set of fields for you, based on the model.
     * It will automatically generate validators for the serializer.
@@ -266,7 +266,7 @@ Features :
 
     class UserSerializer(dt.ModelSerializer):
 
-        class Meta : 
+        class Meta :
             model = User
             fields = ('id','username','email')
 
@@ -278,7 +278,7 @@ For example:
 
     class UserSerializer(dt.ModelSerializer):
 
-        class Meta : 
+        class Meta :
             model = User
             fields = '__all__'
 
@@ -290,10 +290,10 @@ For example:
 
     class UserSerializer(dt.ModelSerializer):
 
-        class Meta : 
+        class Meta :
             model = User
             exclude = ('email',)
-    
+
 
 Read&Write only fields
 ----------------------
@@ -320,7 +320,7 @@ Allow only requests with JSON content, instead of the default of JSON or form da
         ]
     }
 
-    or 
+    or
 
     REST_FRAMEWORK = {
         'DEFAULT_PARSER_CLASSES': [
@@ -328,7 +328,7 @@ Allow only requests with JSON content, instead of the default of JSON or form da
         ]
     }
 
-    or 
+    or
 
     REST_FRAMEWORK = {
         'DEFAULT_PARSER_CLASSES': [
@@ -336,7 +336,7 @@ Allow only requests with JSON content, instead of the default of JSON or form da
         ]
     }
 
-**NOTE**: ujson must be installed to use UJSONParser.   
+**NOTE**: ujson must be installed to use UJSONParser.
 
 **NOTE**: orjson must be installed to use ORJSONParser.
 
@@ -372,7 +372,7 @@ Use JSON as the main media type.
         ]
     }
 
-**NOTE**: ujson must be installed to use UJSONRenderer.   
+**NOTE**: ujson must be installed to use UJSONRenderer.
 
 **NOTE**: orjson must be installed to use ORJSONRenderer.
 
@@ -393,7 +393,7 @@ An ``HttpResponse`` subclass that helps to create a JSON-encoded response. Its d
             data = {"username":"test"}
             return dt.JsonResponse(data,status=200)
 
-    or 
+    or
 
     class UserInfo(APIView):
         def get(self,request):
@@ -407,14 +407,14 @@ An ``HttpResponse`` subclass that helps to create a JSON-encoded response. Its d
             data = {"username":"test"}
             return dt.ORJSONResponse(data,status=200)
 
-**NOTE**: ujson must be installed to use UJSONResponse.   
+**NOTE**: ujson must be installed to use UJSONResponse.
 
 **NOTE**: orjson must be installed to use ORJSONResponse.
 
-    
+
 Also drf-turbo provides an easy way to return a success or error response using ``SuccessResponse`` or ``ErrorResponse`` clasess.
 
-for example : 
+for example :
 
 .. code:: python
 
@@ -425,7 +425,7 @@ for example :
             if not serializer.is_valid():
                 return dt.ErrorResponse(serializer.errors)
                  # returned response :  {'message':'Bad request', data : ``serializer_errros``, 'error': True} with status = 400
-            return dt.SuccessResponse(data)     
+            return dt.SuccessResponse(data)
             # returned response :  {'message':'Success', data : {"username":"test"} , 'error': False} with status = 200
 
 
@@ -462,7 +462,7 @@ and finally add these lines in ``urls.py``
     from django.views.generic import TemplateView
     from rest_framework.schemas import get_schema_view as schema_view
     from drf_turbo.openapi import SchemaGenerator
-    
+
     urlpatterns = [
         # YOUR PATTERNS
  	path('openapi', schema_view(
@@ -477,7 +477,7 @@ and finally add these lines in ``urls.py``
             extra_context={'schema_url':'openapi-schema'}
         ), name='swagger-ui'),
     ]
-    
+
 Now go to http://127.0.0.1:8000/docs
 
 Credits

--- a/README.rst
+++ b/README.rst
@@ -22,15 +22,12 @@ drf-turbo
      :alt: Downloads
 
 
+Overview
+------------
+drf-turbo is a drop-in serializer for Django REST Framework (DRF). drf-turbo serializers run around 7.75 times faster
+than what what you get from DRF's packaged serializer.
 
-An alternative serializer implementation for REST framework written in cython built for speed.
-
-
-* Free software: MIT license
-* Documentation: https://drf-turbo.readthedocs.io.
-
-
-**NOTE**: Cython is required to build this package.
+**NOTE**: It is written in Cython, which is required to build this package.
 
 
 Requirements
@@ -487,3 +484,7 @@ This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypack
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
+
+License
+------------
+* Free software: MIT license

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,11 @@ Installation
 
     $ pip install drf-turbo
 
+To install Cython on MacOS `via Brew <https://formulae.brew.sh/formula/cython>`_:
+
+.. code-block:: console
+
+    $ brew install cython
 
 Performance
 -----------

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ To install Cython on MacOS `via Brew <https://formulae.brew.sh/formula/cython>`_
 
 Performance
 -----------
-`drf-turbo` serialization performance averages 86% faster than DRF's standard serializer.
+`drf-turbo` serialization, deserialization and validation performance averages 86% faster than DRF's standard serializer.
 
 For more details, visit the `benchmarks section <https://drf-turbo.readthedocs.io/en/latest/performance.html>`_ of the docs.
 

--- a/README.rst
+++ b/README.rst
@@ -58,9 +58,15 @@ Installation
 
 Performance
 -----------
-Using Pydantic's benchmarking code, `drf-turbo` serialization performance is 86% faster than DRF's standard serializer.
+`drf-turbo` serialization performance averages 86% faster than DRF's standard serializer.
 
-For more details, visit the [benchmarks section](https://drf-turbo.readthedocs.io/en/latest/performance.html?fbclid=IwAR2kUbUUUWir8vMYPXhFIG7ggsydLlVmtqHlH2yRKm6k1SuvUhm82AyJGnY) of the docs.
+For more details, visit the `benchmarks section <https://drf-turbo.readthedocs.io/en/latest/performance.html>`_ of the docs.
+
+Documentation & Support
+-----------
+Documentation for the project is available at https://drf-turbo.readthedocs.io.
+
+For questions and support, use github issues
 
 Examples
 ========

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -2,8 +2,21 @@
 Performance Benchmarks
 **********************
 
+Using Pydantic's benchmarking code, drf-turbo performs serialization nearly *eight times faster* than a standard
+django-rest-framework configuration.
 
-Using Pydantic's own benchmark :
+
+.. csv-table::
+       :header: "Package", "Version", "Relative Performance", "Mean Validation Time"
+
+        "drf-turbo","0.1.1","","113.79μs"
+        "django-rest-framework","3.12.4","7.78x slower","885.47μs"
+
+See `Pydantic benchmarking page <https://pydantic-docs.helpmanual.io/benchmarks/>`_ for more relative performance data
+and of the a link to the benchmarking code.
+
+
+Raw scores:
 ::
 
           drf-turbo best=111.754μs/iter avg=113.794μs/iter stdev=1.274μs/iter version=0.1.1

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -2,8 +2,8 @@
 Performance Benchmarks
 **********************
 
-Using Pydantic's benchmarking code, drf-turbo performs serialization nearly *eight times faster* than a standard
-django-rest-framework configuration.
+Using Pydantic's benchmarking code, drf-turbo performs serialization, deserialization and validation nearly
+*eight times faster* than a standard django-rest-framework configuration.
 
 
 .. csv-table::

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -6,15 +6,14 @@ Performance Benchmarks
 Using Pydantic's own benchmark :
 ::
 
+          drf-turbo best=111.754μs/iter avg=113.794μs/iter stdev=1.274μs/iter version=0.1.1
+          django-rest-framework best=856.090μs/iter avg=885.471μs/iter stdev=39.377μs/iter version=3.12.4
           pydantic best=103.525μs/iter avg=106.093μs/iter stdev=2.720μs/iter version=1.8.2
           attrs + cattrs best=67.449μs/iter avg=67.766μs/iter stdev=0.388μs/iter version=21.2.0
-          valideer best=90.025μs/iter avg=91.712μs/iter stdev=1.579μs/iter version=0.4.2
-          marshmallow best=198.683μs/iter avg=201.499μs/iter stdev=2.192μs/iter version=3.14.0
-          voluptuous best=195.394μs/iter avg=197.416μs/iter stdev=2.399μs/iter version=0.12.2
-          trafaret best=221.880μs/iter avg=223.723μs/iter stdev=1.050μs/iter version=2.1.0
-          schematics best=728.707μs/iter avg=745.313μs/iter stdev=11.523μs/iter version=2.1.1
-          django-rest-framework best=856.090μs/iter avg=885.471μs/iter stdev=39.377μs/iter version=3.12.4
-          drf-turbo best=111.754μs/iter avg=113.794μs/iter stdev=1.274μs/iter version=0.1.1
           cerberus best=1561.922μs/iter avg=1638.844μs/iter stdev=44.257μs/iter version=1.3.4
-
+          marshmallow best=198.683μs/iter avg=201.499μs/iter stdev=2.192μs/iter version=3.14.0
+          valideer best=90.025μs/iter avg=91.712μs/iter stdev=1.579μs/iter version=0.4.2
+          voluptuous best=195.394μs/iter avg=197.416μs/iter stdev=2.399μs/iter version=0.12.2
+          schematics best=728.707μs/iter avg=745.313μs/iter stdev=11.523μs/iter version=2.1.1
+          trafaret best=221.880μs/iter avg=223.723μs/iter stdev=1.050μs/iter version=2.1.0
 


### PR DESCRIPTION
Some changes to handle #7.

- Surfaces key benchmark data to readme, cleans up file whitespace
- Adds table with relative performance and semi-sorted raw data

I wasn't sure if you needed the docs regenerated, or would do that as part of a release.